### PR TITLE
Fixed CI build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ The library internally checks for dependencies – and will report this to the a
 
 ## CI builds
 
-[macOS](https://gnaudio.visualstudio.com/jabra-browser-integration/_build?definitionId=138):
+### macOS CI build - branch v3.0
 
-![macOS CI build](https://gnaudio.visualstudio.com/jabra-browser-integration/_apis/build/status/jabra-browser-integration-macOS)
+[![macOS CI build](https://gnaudio.visualstudio.com/jabra-browser-integration/_apis/build/status/jabra-browser-integration-macOS?branchName=v3.0)](https://gnaudio.visualstudio.com/jabra-browser-integration/_build/latest?definitionId=138&branchName=v3.0)
 
-[Windows](https://gnaudio.visualstudio.com/jabra-browser-integration/_build?definitionId=139):
+### Windows CI build - branch v3.0
 
-![Windows CI build](https://gnaudio.visualstudio.com/jabra-browser-integration/_apis/build/status/jabra-browser-integration-Windows)
+[![Windows CI build](https://gnaudio.visualstudio.com/jabra-browser-integration/_apis/build/status/jabra-browser-integration-Windows?branchName=v3.0)](https://gnaudio.visualstudio.com/jabra-browser-integration/_build/latest?definitionId=139&branchName=v3.0)
 
 ## Getting started with using the API in your web applications
 


### PR DESCRIPTION
Build badges links updated, and made specific for v3.0 branch.

Don't forget to clean this up if/when the branch is merged to master.
I have added the branch name to the section title so it is obvious what it is showing.