### PR TITLE
Fail signfile.cmd if there is an error in running signtoool.exe

### DIFF
--- a/src/InstallerWindows/signfile.cmd
+++ b/src/InstallerWindows/signfile.cmd
@@ -1,4 +1,5 @@
 echo off
 echo Code signing...
 "C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe" sign /f %1 /p %2 /d "Jabra Chrome Host" /du http://www.jabra.com /t http://timestamp.verisign.com/scripts/timstamp.dll %3
+if %errorlevel% neq 0 exit /b %errorlevel%
 echo Done


### PR DESCRIPTION
I noticed that the build pipeline silently swallows a failed attempt to sign.
This is because the signfile.cmd ends with an "echo Done", so the return code is always 0.
I have now added an error check and early exit.