### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The library internally checks for dependencies – and will report this to the a
 | Windows (Windows 7 or newer)  | [JabraChromeHost2.0.0.msi](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost2.0.0.msi) | Chromehost 2.0 |
 | Windows (Windows 7 or newer)  | [JabraChromeHost2.0.2.msi](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost2.0.2.msi) | Chromehost 2.0 (3CX only) |
 | Windows (Windows 7 or newer)  | [JabraChromeHost0.51.msi](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost0.51.msi) | Security fix to allow beta testing |
-| macOS (El Capitan or newer)   | [JabraChromeHost2.0.0.dmg](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost2.0.0.dmg) | Chromehost 2.0 |
-| macOS (El Capitan or newer)   | [JabraChromeHost2.0.2.dmg](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost2.0.2.dmg) | Chromehost 2.0 (3CX only) |
+| macOS (High Sierra or newer)   | [JabraChromeHost2.0.0.dmg](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost2.0.0.dmg) | Chromehost 2.0 |
+| macOS (High Sierra or newer)   | [JabraChromeHost2.0.2.dmg](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost2.0.2.dmg) | Chromehost 2.0 (3CX only) |
 | macOS (El Capitan or newer)   | [JabraChromeHost0.5.dmg](https://gnaudio.github.io/jabra-browser-integration/download/JabraChromeHost0.5.dmg) | Old Mac release |
 
 ## CI builds


### PR DESCRIPTION
the 2.0.x.dmg files are using the APFS-type file system and is unmountable by El Capitan, or Sierra. It should say High Sierra or newer because Apple introduced APFS in macOS version 10.13 High Sierra. Running this command on the JabraChromeHost2.0.0.dmg or JabraChromeHost2.0.2.dmg will return that the file system used in the DMG is APFS: hdiutil attach -verbose filepath/to/file.dmg